### PR TITLE
Explicitly pass secrets.

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -85,14 +85,14 @@ Although we recommend you stick with the default setup provided by the template,
 This list is not exhaustive, but gives you an idea of where to look.
 
 1. **Changing how continuous integration (CI) works**.
-The configuration files in `.github/workflows` are based on the [PAM](https://github.com/arup-group/pam) package workflows.
+The configuration files in `.github/workflows` are based on the [PAM](https://github.com/arup-group/pam) package workflows and rely on the City Modelling Lab's [reusable workflows](https://github.com/arup-group/actions-city-modelling-lab).
 They will run different levels of tests when pushing new commits and when opening pull requests.
 You may want to change some of this configuration, e.g., the python versions that tests are run on or whether to notify a slack channel when CI fails/succeeds.
 
 2. **Adding [repository secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository) for use in CI**.
 To upload your package to an AWS S3 bucket you will need the secrets `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_S3_CODE_BUCKET` available in your repository.
 You also need secrets for uploading to Anaconda and initiating the Slack notification bot.
-You can find all the secrets you need for different actions in the City Modelling Lab [actions repository](https://github.com/arup-group/actions-city-modelling-lab).
+You can find all the secrets you need for different actions in the City Modelling Lab [reusable workflow repository](https://github.com/arup-group/actions-city-modelling-lab).
 
 3. **Adding logos**.
 The `resources` directory includes a logo subdirectory that you can add any branding for your package.

--- a/{{cookiecutter.project_slug}}/.github/workflows/commit-ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/commit-ci.yml
@@ -25,4 +25,7 @@ jobs:
     needs: test
     if: needs.test.result == 'success'
     uses: arup-group/actions-city-modelling-lab/.github/workflows/aws-upload.yml@main
-    secrets: inherit
+    secrets:
+      AWS_ACCESS_KEY_ID: {% raw %}${{ secrets.AWS_ACCESS_KEY_ID }}{% endraw %}
+      AWS_SECRET_ACCESS_KEY: {% raw %}${{ secrets.AWS_SECRET_ACCESS_KEY }}{% endraw %}
+      AWS_S3_CODE_BUCKET: {% raw %}${{ secrets.AWS_S3_CODE_BUCKET }}{% endraw %}

--- a/{{cookiecutter.project_slug}}/.github/workflows/daily-scheduled-ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/daily-scheduled-ci.yml
@@ -25,8 +25,10 @@ jobs:
 
   slack-notify-ci:
     needs: test
+    if: always()
     uses: arup-group/actions-city-modelling-lab/.github/workflows/slack-notify.yml@main
-    secrets: inherit
+    secrets:
+      SLACK_WEBHOOK: {% raw %}${{ secrets.SLACK_WEBHOOK }}{% endraw %}
     with:
       result: needs.test.result
       channel: {{ cookiecutter.project_slug }}-feed

--- a/{{cookiecutter.project_slug}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/docs.yml
@@ -28,8 +28,9 @@ jobs:
     needs: [docs-test, docs-update-latest]
     if: always() && contains(needs.*.result, 'failure')
     uses: arup-group/actions-city-modelling-lab/.github/workflows/slack-notify.yml@main
-    secrets: inherit
+    secrets:
+      SLACK_WEBHOOK: {% raw %}${{ secrets.SLACK_WEBHOOK }}{% endraw %}
     with:
       result: 'failure'
-      channel: pam-feed
+      channel: {{ cookiecutter.project_slug }}-feed
       message: Docs Build

--- a/{{cookiecutter.project_slug}}/.github/workflows/pre-release.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/pre-release.yml
@@ -8,5 +8,7 @@ on:
 jobs:
   conda-build:
     uses: arup-group/actions-city-modelling-lab/.github/workflows/conda-build.yml@main
+    secrets:
+      ANACONDA_TOKEN: {% raw %}${{ secrets.ANACONDA_TOKEN }}{% endraw %}
     with:
       package_name: {{ cookiecutter.project_slug }}

--- a/{{cookiecutter.project_slug}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/release.yml
@@ -7,7 +7,8 @@ on:
 jobs:
   conda-upload:
     uses: arup-group/actions-city-modelling-lab/.github/workflows/conda-upload.yml@main
-    secrets: inherit
+    secrets:
+      ANACONDA_TOKEN: {% raw %}${{ secrets.ANACONDA_TOKEN }}{% endraw %}
     with:
       package_name: {{ cookiecutter.project_slug }}
 


### PR DESCRIPTION
You can use `secrets: inherit` for repos in the `arup-group` org, but not if you upload to a personal repo. 

This ensures that secrets will be passed either way.