### PR TITLE
Add pypi upload; fix aws secrets checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Fixed
+
+- Only run AWS upload job if secrets are defined.
+
+### Added
+
+- Upload to PyPI option.
+
+### Changed
+
+- Delete conda recipe if upload to conda is not desired.
+- `index_package` cookiecutter parameter split into `upload_conda_package` and `upload_pypi_package`.
+
 ## [v0.1.0] - 05-01-2024
 
 These initial changes are all relative to the [original cookiecutter PyPackage repository](https://github.com/audreyfeldroy/cookiecutter-pypackage), of which this is a fork.

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,9 +8,13 @@
   "package_name": "{{ cookiecutter.repository_name }}",
   "module_name": "{{ cookiecutter.repository_name }}",
   "project_short_description": "Python Boilerplate contains all the boilerplate you need to create a Python package.",
-  "index_package": [
-    "conda",
-    "none"
+  "upload_pypi_package": [
+    "y",
+    "n"
+  ],
+  "upload_conda_package": [
+    "y",
+    "n"
   ],
   "conda_channel": "{{ cookiecutter.github_username }}",
   "version": "0.1.0",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -35,6 +35,18 @@ if __name__ == "__main__":
         remove_file(notebook_dir / "1_intro_to_{{cookiecutter.module_name}}.ipynb")
         remove_dir(notebook_dir)
 
+    if "{{ cookiecutter.upload_conda_package|lower }}" == "n":
+        recipe_dir = Path("conda.recipe")
+        remove_file(recipe_dir / "meta.yaml")
+        remove_dir(recipe_dir)
+
+    if (
+        "{{ cookiecutter.upload_conda_package|lower }}" == "n"
+        and "{{ cookiecutter.upload_pypi_package|lower }}" == "n"
+    ):
+        workflow_dir = Path(".github") / "workflows"
+        remove_file(workflow_dir / "pre-release.yml")
+
     if "{{ cookiecutter.create_docker_file|lower }}" == "n":
         for file in [".dockerignore", "Dockerfile"]:
             remove_file(file)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ minversion = "6.0"
 # `-n2` - parallelise over two threads (uses pytest-xdist)
 # `--keep-baked-projects` - keep the cookiecutter projects that are generated in the tests (they will be stored in a temporary directory)
 
-addopts = "-rav -n2 --keep-baked-projects"
+addopts = "-rav -nauto --keep-baked-projects"
 testpaths = ["tests"]
 
 [tool.black]

--- a/schema.yaml
+++ b/schema.yaml
@@ -39,61 +39,62 @@ properties:
     type: string
     default: "Python Boilerplate contains all the boilerplate you need to create a Python package."
     description: A 1-sentence description of what your Python package does.
-  index_package:
+
+  upload_pypi_package:
     type: array
-    description: Where to release new packaged versions of the project to. If "none", releases will not be published beyond GitHub.
+    description: Whether to upload the package to PyPI on each release of a new version.
     uniqueItems: true
     minItems: 1
-    items:
+    items: &y_n_items
       type: string
-      default: "conda"
-      enum:
-        - conda
-        - none
+      default: "y"
+      enum: ["y", "n"]
+
+  upload_conda_package:
+    type: array
+    description: Whether to upload the package to an Anaconda channel on each release of a new version.
+    uniqueItems: true
+    minItems: 1
+    items: *y_n_items
+
   conda_channel:
     type: string
     default: "[github_username]"
     description: Your anaconda channel, if releases of your package will be uploaded to Anaconda.
+
   version:
     type: string
     default: "0.1.0"
     description: The starting version number of the package.
+
   create_jupyter_notebook_directory:
     type: array
     description: If "y", an `examples` directory will be created in which Jupyter Notebooks can be saved. These notebooks will be rendered in the documentation and will be formatted with Black and Ruff.
     uniqueItems: true
     minItems: 1
-    items:
-      type: string
-      default: "y"
-      enum: ["y", "n"]
+    items: *y_n_items
+
   command_line_interface:
     type: array
     description: If "y", a `cli.py` file will be included in the project source code based on using `Click`.
     uniqueItems: true
     minItems: 1
-    items:
-      type: string
-      default: "y"
-      enum: ["y", "n"]
+    items: *y_n_items
+
   create_author_file:
     type: array
     description: If "y", create an authors file.
     uniqueItems: true
     minItems: 1
-    items:
-      type: string
-      default: "y"
-      enum: ["y", "n"]
+    items: *y_n_items
+
   create_docker_file:
     type: array
     description: If "y", create an Dockerfile which allows a Docker image of the project to be built in a linux virtual machine with a basic Bash entry-point.
     uniqueItems: true
     minItems: 1
-    items:
-      type: string
-      default: "y"
-      enum: ["y", "n"]
+    items: *y_n_items
+
   open_source_license:
     type: array
     description: Choose a [license](https://choosealicense.com/).

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -101,6 +101,31 @@ def test_bake_without_jupyter_notebooks(cookies):
     assert "page.nb_url" not in html_override
 
 
+def test_bake_without_conda(cookies):
+    result = cookies.bake(extra_context={"upload_conda_package": "n"})
+
+    found_toplevel_files = [i.name for i in result.project_path.iterdir()]
+    assert "conda.recipe" not in found_toplevel_files
+
+
+@pytest.mark.parametrize("destination", ["conda", "pypi"])
+def test_bake_without_indexing_one(cookies, destination):
+    result = cookies.bake(extra_context={f"upload_{destination}_package": "n"})
+
+    for workflow in ["pre-release", "release"]:
+        github_workflow = (
+            result.project_path / ".github" / "workflows" / f"{workflow}.yml"
+        ).read_text()
+        assert f"{destination}-" not in github_workflow
+
+
+def test_bake_without_indexing_all(cookies):
+    result = cookies.bake(extra_context={"upload_pypi_package": "n", "upload_conda_package": "n"})
+
+    workflows = [i.name for i in (result.project_path / ".github" / "workflows").iterdir()]
+    assert "pre-release.yml" not in workflows
+
+
 @pytest.mark.parametrize(
     ["license", "target_string"],
     [

--- a/{{cookiecutter.repository_name}}/.github/workflows/commit-ci.yml
+++ b/{{cookiecutter.repository_name}}/.github/workflows/commit-ci.yml
@@ -23,13 +23,22 @@ jobs:
       {%- endif %}
       lint: false
 
+  aws-pre-check:
+    runs-on: ubuntu-latest
+    outputs:
+      aws-secrets-exist: {% raw %}${{ steps.secret-checker.outputs.SECRETS_EXIST }}{% endraw %}
+    steps:
+      - id: secret-checker
+        name: 'Check secret access for fast fail'
+        run: |
+          echo "SECRETS_EXIST=$AWS_SECRETS_EXIST" >> $GITHUB_OUTPUT
+          echo "SECRETS_EXIST=$AWS_SECRETS_EXIST" >> $GITHUB_STEP_SUMMARY
+        env:
+          AWS_SECRETS_EXIST: {% raw %}${{ secrets.AWS_ACCESS_KEY_ID != '' && secrets.AWS_SECRET_ACCESS_KEY != '' && secrets.AWS_S3_CODE_BUCKET != '' }}{% endraw %}
+
   aws-upload:
-    needs: test
-    env:
-      aws_access_key_id: {% raw %}${{ secrets.AWS_ACCESS_KEY_ID }}{% endraw %}
-      aws_secret_access_key: {% raw %}${{ secrets.AWS_SECRET_ACCESS_KEY }}{% endraw %}
-      aws_s3_code_bucket: {% raw %}${{ secrets.AWS_S3_CODE_BUCKET }}{% endraw %}
-    if: needs.test.result == 'success' && env.aws_access_key_id != '' && env.aws_secret_access_key != '' && env.aws_s3_code_bucket != ''
+    needs: [test, aws-pre-check]
+    if: always() && needs.test.result == 'success' && needs.aws-pre-check.outputs.aws-secrets-exist == 'true'
     uses: arup-group/actions-city-modelling-lab/.github/workflows/aws-upload.yml@main
     secrets:
       AWS_ACCESS_KEY_ID: {% raw %}${{ secrets.AWS_ACCESS_KEY_ID }}{% endraw %}

--- a/{{cookiecutter.repository_name}}/.github/workflows/pre-release.yml
+++ b/{{cookiecutter.repository_name}}/.github/workflows/pre-release.yml
@@ -6,9 +6,20 @@ on:
       - 'v*'
 
 jobs:
+  {% if cookiecutter.upload_conda_package|lower == 'y' -%}
   conda-build:
     uses: arup-group/actions-city-modelling-lab/.github/workflows/conda-build.yml@main
     secrets:
       ANACONDA_TOKEN: {% raw %}${{ secrets.ANACONDA_TOKEN }}{% endraw %}
     with:
       package_name: {{ cookiecutter.package_name }}
+  {% endif %}
+
+  {% if cookiecutter.upload_pypi_package|lower == 'y' -%}
+  pip-build:
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/pip-build.yml@main
+    secrets:
+      TEST_PYPI_API_TOKEN: {% raw %}${{ secrets.TEST_PYPI_API_TOKEN }}{% endraw %}
+    with:
+      package_name: {{ cookiecutter.package_name }}
+  {% endif %}

--- a/{{cookiecutter.repository_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.repository_name}}/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     types: [released]
 
 jobs:
+  {% if cookiecutter.upload_conda_package|lower == 'y' -%}
   conda-upload:
     uses: arup-group/actions-city-modelling-lab/.github/workflows/conda-upload.yml@main
     secrets:
@@ -12,6 +13,17 @@ jobs:
     with:
       package_name: {{ cookiecutter.package_name }}
       build_workflow: pre-release.yml
+  {% endif %}
+
+  {% if cookiecutter.upload_pypi_package|lower == 'y' -%}
+  pip-upload:
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/pip-upload.yml@main
+    secrets:
+      PYPI_API_TOKEN: {% raw %}${{ secrets.PYPI_API_TOKEN }}{% endraw %}
+    with:
+      package_name: {{ cookiecutter.package_name }}
+      build_workflow: pre-release.yml
+  {% endif %}
 
   docs-stable:
     permissions:

--- a/{{cookiecutter.repository_name}}/README.md
+++ b/{{cookiecutter.repository_name}}/README.md
@@ -26,9 +26,11 @@ To install {{ cookiecutter.module_name }}
 
 
 ``` shell
-{% if cookiecutter.index_package == "conda" %}
+{% if cookiecutter.upload_conda_package == "y" %}
 mamba create -n {{ cookiecutter.repository_name }} -c conda-forge -c {{ cookiecutter.conda_channel }} {{ cookiecutter.package_name }}
-{% elif cookiecutter.index_package == "pypi" %}
+{% elif cookiecutter.upload_pypi_package == "y" %}
+mamba create -n {{ cookiecutter.repository_name }} -c conda-forge python
+mamba activate {{ cookiecutter.repository_name }}
 pip install {{ cookiecutter.package_name }}
 {% else %}
 git clone git@github.com:{{ cookiecutter.repository_owner }}/{{ cookiecutter.repository_name }}.git

--- a/{{cookiecutter.repository_name}}/docs/installation.md
+++ b/{{cookiecutter.repository_name}}/docs/installation.md
@@ -6,18 +6,19 @@
 As a `{{ cookiecutter.module_name }}` user, it is easiest to install using the [mamba](https://mamba.readthedocs.io/en/latest/index.html) package manager, as follows:
 
 1. Install mamba with the [Mambaforge](https://github.com/conda-forge/miniforge#mambaforge) executable for your operating system.
-2. Open the command line (or the "miniforge prompt" in Windows).
-{% if cookiecutter.index_package == "conda" %}
-3. Create the {{ cookiecutter.repository_name }} mamba environment: `mamba create -n {{ cookiecutter.repository_name }} -c conda-forge -c {{ cookiecutter.conda_channel }} {{ cookiecutter.repository_name }}`
-4. Activate the {{ cookiecutter.repository_name }} mamba environment: `mamba activate {{ cookiecutter.repository_name }}`
+1. Open the command line (or the "miniforge prompt" in Windows).
+{% if cookiecutter.upload_conda_package == "y" %}
+1. Create the {{ cookiecutter.repository_name }} mamba environment: `mamba create -n {{ cookiecutter.repository_name }} -c conda-forge -c {{ cookiecutter.conda_channel }} {{ cookiecutter.package_name }}`
+{% elif cookiecutter.upload_pypi_package == "y" %}
+1. Create a {{ cookiecutter.repository_name }} mamba environment: `mamba create -n {{ cookiecutter.repository_name }} -c conda-forge python`
+1. Activate the {{ cookiecutter.repository_name }} mamba environment: `mamba activate {{ cookiecutter.repository_name }}`
+1. Install the {{ cookiecutter.package_name }} package into the environment: `pip install {{ cookiecutter.package_name }}`
 {% else %}
-1. Install mamba with the [Mambaforge](https://github.com/conda-forge/miniforge#mambaforge) executable for your operating system.
-2. Open the command line (or the "miniforge prompt" in Windows).
-3. Download (a.k.a., clone) the {{ cookiecutter.repository_name }} repository: `git clone git@github.com:{{ cookiecutter.repository_owner }}/{{ cookiecutter.repository_name }}.git`
-4. Change into the `{{ cookiecutter.repository_name }}` directory: `cd {{ cookiecutter.repository_name }}`
-5. Create the {{ cookiecutter.repository_name }} mamba environment: `mamba create -n {{ cookiecutter.repository_name }} -c conda-forge -c city-modelling-lab --file requirements/base.txt`
-6. Activate the {{ cookiecutter.repository_name }} mamba environment: `mamba activate {{ cookiecutter.repository_name }}`
-7. Install the {{ cookiecutter.package_name }} package into the environment, ignoring dependencies (we have dealt with those when creating the mamba environment): `pip install --no-deps .`
+1. Download (a.k.a., clone) the {{ cookiecutter.repository_name }} repository: `git clone git@github.com:{{ cookiecutter.repository_owner }}/{{ cookiecutter.repository_name }}.git`
+1. Change into the `{{ cookiecutter.repository_name }}` directory: `cd {{ cookiecutter.repository_name }}`
+1. Create the {{ cookiecutter.repository_name }} mamba environment: `mamba create -n {{ cookiecutter.repository_name }} -c conda-forge -c city-modelling-lab --file requirements/base.txt`
+1. Activate the {{ cookiecutter.repository_name }} mamba environment: `mamba activate {{ cookiecutter.repository_name }}`
+1. Install the {{ cookiecutter.package_name }} package into the environment, ignoring dependencies (we have dealt with those when creating the mamba environment): `pip install --no-deps .`
 {% endif %}
 
 All together:


### PR DESCRIPTION
1. Add option to upload to PyPI (requires more secrets to be defined).
2. Fix AWS secrets checker so that the AWS upload job will only run if the secrets are defined.