### PR TITLE
Switch package uploading to default to "n"

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,12 +9,12 @@
   "module_name": "{{ cookiecutter.repository_name }}",
   "project_short_description": "Python Boilerplate contains all the boilerplate you need to create a Python package.",
   "upload_pypi_package": [
-    "y",
-    "n"
+    "n",
+    "y"
   ],
   "upload_conda_package": [
-    "y",
-    "n"
+    "n",
+    "y"
   ],
   "conda_channel": "{{ cookiecutter.github_username }}",
   "version": "0.1.0",

--- a/docs/stay_updated.md
+++ b/docs/stay_updated.md
@@ -1,0 +1,58 @@
+# Updating your project
+
+This repository isn't just for creating your project in the first place.
+It can be used to update your project when fixes / features are added to the template *and* to update your project when you change your mind about the input parameters you used when you [generated your project][step-2-generate-your-package].
+
+!!! note
+    There is a limit to how well Cruft can apply updates / changes to input parameters.
+    More likely than not, it will produce a lot of `.rej` files explaining what updates it tried to implement, but failed to merge in.
+    You will need to go through each of these manually and make the changes in the corresponding source code file.
+
+    After each change, delete the corresponding `.rej` file.
+    Your project will not let you commit changes if `.rej` files are still present.
+
+## Keeping your project up-to-date
+
+We may make changes to this template that you want to pull into your project after you have generated it.
+Cruft allows you to do this, and one of your project's CI workflows will verify whether there are new template updates that you might like to merge in.
+
+Check if there are updates:
+
+``` bash
+cruft check
+```
+
+View the diff between your project and the most up-to-date template:
+
+``` bash
+cruft diff
+```
+
+Apply any updates that exist:
+
+``` bash
+cruft update
+```
+
+## Changing input parameters after project generation
+
+You can change your mind on the [input parameters][configuration-values] you gave when initialising the project and use `cruft` to update them.
+
+Changing some inputs will cause you less trouble than others.
+For example, changing the email associated with the project will probably be seamless.
+Changing whether to include a CLI or example notebooks, however, may not be.
+This is because these changes entail the deletion of files / directories when you do not want them.
+
+If you are finding it difficult to make a change, you can try generating a _new_ project with your preferred input parameters and then porting across the changes (make sure to update the parameter values in your initial project's `cruft.json` file.).
+
+!!! example
+
+    To update your project to upload the package to both an Anaconda channel and to PyPI:
+
+    ``` bash
+    cruft update --variables-to-update '{ "upload_conda_package" : "y" , "upload_pypi_package": "y"}'
+    ```
+
+!!! info
+
+    For more info, see the [Cruft documentation](https://cruft.github.io/cruft/#updating-values-of-template-variables)

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -84,6 +84,14 @@ cd python-boilerplate # (1)!
 
 1.  Change this directory name based on the name you gave in `repository_name`.
 
+!!! tip
+
+    If you are generating a project which will be hosted in `arup-group`, it will default to `internal`.
+    Therefore you will need to wait until the project is made public (with a suitable open source license) before you allow uploads of your package to PyPI or an Anaconda channel.
+    This is why the parameters `upload_conda_package` and `upload_pypi_package` default to `n` (i.e. no upload).
+
+    When you're ready to take the leap to a public repository, you can [update your project input parameters][changing-input-parameters-after-project-generation] to enable uploads.
+
 ### Step 3: Create a GitHub Repository
 
 Go to the GitHub page for `[repository_owner]`, e.g. `https://github.com/arup-group` or `https://github.com/ovearup`, and create a new repository with `[repository_name]` (`python-boilerplate`).
@@ -132,11 +140,13 @@ You can keep update this as you go along and need new packages in your project.
 To install the necessary packages to develop your Python package, follow the instructions automatically generated in your new project's README / online documentation (e.g., https://arup-group.github.io/python-boilerplate).
 
 !!! note
-    As you update the requirements that [you define as dependencies][step-4-define-requirements], you should bulldoze your install and recreate it.
+    As you update the requirements that [you define as dependencies][step-5-define-requirements], you should bulldoze your install and recreate it.
     E.g., if you create your environment using mamba/conda:
+
     ```bash
     mamba create -n python-boilerplate -c conda-forge --file requirements/base.txt --file requirements/dev.txt
     ```
+
     You should run this exact same command after updating `requirements/base.txt` and say yes to overriding the existing `python-boilerplate` environment.
     This is a much better way of managing your python environments than adding the dependencies ad-hoc using `mamba install ...`.
 
@@ -171,53 +181,6 @@ By default, the conda package (if you choose to have one built) will build one p
 Usually, your dependencies will be aligned with this: they will also be installable on any architecture.
 However, there are times when you might have a dependency that can not be installed on e.g., Windows.
 If that is the case, be sure to dive into `conda.recipe/meta.yaml` and change some lines in `build` following the comments there.
-
-## Keeping your project up-to-date
-
-We may make changes to this template that you want to pull into your project after you have created it.
-Cruft allows you to do this, and one of your project's CI workflows will verify whether there are new template updates that you might like to merge in.
-
-Check if there are updates:
-``` bash
-cruft check
-```
-
-View the diff between your project and the most up-to-date template:
-``` bash
-cruft diff
-```
-
-Apply any updates that exist:
-
-``` bash
-cruft update
-```
-
-!!! note
-    There is a limit to how well cruft can apply an update.
-    More likely than not, it will produce a lot of `.rej` files explaining what updates it tried to implement, but failed to merge in.
-    You will need to go through each of these manually and make the changes in the corresponding source code file.
-
-## Changing inputs after project generation
-
-You can change your mind on *some* of the input variables you gave when initialising the project and use `cruft` to update them.
-
-The following variables are suitable for updating:
-
-- full_name
-- email
-- github_username
-- repository_owner
-- project_title
-- repository_name
-- package_name
-- module_name
-- project_short_description
-- conda_channel
-- version
-- open_source_license
-
-Even when changing one of these values, be aware that you will need to apply some manual changes based on `.rej` files that cruft will generate.
 
 ## Having problems?
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: Arup Cookiecutter Python Package
 nav:
   - Home: README.md
   - Getting Started: tutorial.md
+  - Stay Updated: stay_updated.md
   - Input Arguments: schema.md
   - Contributing: CONTRIBUTING.md
   - Changelog: CHANGELOG.md

--- a/schema.yaml
+++ b/schema.yaml
@@ -45,9 +45,9 @@ properties:
     description: Whether to upload the package to PyPI on each release of a new version.
     uniqueItems: true
     minItems: 1
-    items: &y_n_items
+    items: &n_y_items
       type: string
-      default: "y"
+      default: "n"
       enum: ["y", "n"]
 
   upload_conda_package:
@@ -55,7 +55,7 @@ properties:
     description: Whether to upload the package to an Anaconda channel on each release of a new version.
     uniqueItems: true
     minItems: 1
-    items: *y_n_items
+    items: *n_y_items
 
   conda_channel:
     type: string
@@ -72,7 +72,10 @@ properties:
     description: If "y", an `examples` directory will be created in which Jupyter Notebooks can be saved. These notebooks will be rendered in the documentation and will be formatted with Black and Ruff.
     uniqueItems: true
     minItems: 1
-    items: *y_n_items
+    items: &y_n_items
+      type: string
+      default: "y"
+      enum: ["y", "n"]
 
   command_line_interface:
     type: array


### PR DESCRIPTION
`arup-groups` are default not public so projects shouldn't try to upload to public package indexes by default.