### PR TITLE
Add fixes + cleanup

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -17,7 +17,6 @@
     "y"
   ],
   "conda_channel": "{{ cookiecutter.github_username }}",
-  "version": "0.1.0",
   "command_line_interface": [
     "y",
     "n"

--- a/docs/stay_updated.md
+++ b/docs/stay_updated.md
@@ -11,6 +11,9 @@ It can be used to update your project when fixes / features are added to the tem
     After each change, delete the corresponding `.rej` file.
     Your project will not let you commit changes if `.rej` files are still present.
 
+!!! info
+    You can run updates from within your project's [development environment](tutorial.md#step-6-create-a-development-environment-for-your-project) since `cruft` is installed into it.
+
 ## Keeping your project up-to-date
 
 We may make changes to this template that you want to pull into your project after you have generated it.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -164,6 +164,11 @@ To upload to an AWS S3 bucket you will need the secrets `AWS_ACCESS_KEY_ID`, `AW
 You also need secrets for initiating the Slack notification bot and uploading to an AWS S3 bucket (+ possibly some AWS terraforming).
 You can find all the secrets you need for different actions in the City Modelling Lab [reusable workflow repository](https://github.com/arup-group/actions-city-modelling-lab).
 
+!!! note:
+    Some secrets should be stored in [GitHub environments](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment).
+    Namely, releasing packages to public packages indexes should be in `pre-release` (for `.github/workflows/pre-release.yml` job secrets) and `release` (for `.github/workflows/release.yml` job secrets) environments.
+    We recommend you then place protection rules on those environments to only allow maintainers to release the workflow jobs.
+
 3. **Adding logos**.
 The `resources` directory includes a logo subdirectory that you can add any branding for your package.
 E.g., `resources/logos/title.png` will be shown at the top of the README, or you can add a [favicon](https://squidfunk.github.io/mkdocs-material/setup/changing-the-logo-and-icons/#favicon) and then link it to your documentation.

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -4,19 +4,10 @@ import sys
 MODULE_REGEX = r"^[_a-zA-Z][_a-zA-Z0-9]+$"
 
 module_name = "{{ cookiecutter.module_name }}"
-version = "{{ cookiecutter.version }}"
 
 if not re.match(MODULE_REGEX, module_name):
     print(
         f"ERROR: The package name ({module_name}) is not a valid Python module name. Please do not use a - and use _ instead"
-    )
-
-    # Exit to cancel project
-    sys.exit(1)
-
-if version.startswith("v"):
-    print(
-        f"ERROR: The version ({version}) should not start with `v`. Remove the `v` and try again."
     )
 
     # Exit to cancel project

--- a/schema.yaml
+++ b/schema.yaml
@@ -1,5 +1,9 @@
-$schema: http://json-schema.org/draft-07/schema#
-description: You will be prompted to fill these values when you create your Python project. If you do not know what value to provide, press _enter_ and a default value will be used.
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema#
+
+$schema: "https://json-schema.org/draft/2020-12/schema"
+description: >-
+  You will be prompted to fill these values when you create your Python project.
+  If you do not know what value to provide, press _enter_ and a default value will be used.
 
 additionalProperties: false
 properties:
@@ -7,34 +11,53 @@ properties:
     type: string
     default: "Ove Arup"
     description: Your full name.
+
   email:
     type: string
     default: "ove.arup@arup.com"
     description: Your email address.
+
   github_username:
     type: string
     default: "ovearup"
     description: Your GitHub username.
+
   project_title:
     type: string
     default: "Python Boilerplate"
     description: The headline name of your new Python package project. This is used in documentation, so spaces and any characters are fine here.
+
   repository_owner:
     type: string
     default: "arup-group"
-    description: The owner of your GitHub repository (referring to e.g., https://github.com/arup-group). For personal projects, this can be your GitHub username. For Arup projects, this should be `arup-group`
+    description: >-
+      The owner of your GitHub repository (referring to e.g., https://github.com/arup-group).
+      For personal projects, this can be your GitHub username. For Arup projects, this should be `arup-group`.
+
   repository_name:
     type: string
     default: "Lower case equivalent of [project_title] with spaces and dashes (-) replaced with an underscore (_)"
-    description: Name of the github repository where you will host your project (i.e., https://github.com/[repository_owner]/[repository_name]). Typically, it is the "slugified" version of `project_title` (e.g. `My software package` -> `my_software_package`) or an abbreviation derived from it (e.g., `Population Activity Modeller` -> `pam`).
+    description: >-
+      Name of the github repository where you will host your project (i.e., https://github.com/[repository_owner]/[repository_name]).
+      Typically, it is the "slugified" version of `project_title` (e.g. `My software package` -> `my_software_package`) or an abbreviation derived from it (e.g., `Population Activity Modeller` -> `pam`).
+
   package_name:
     type: string
     default: "[repository_name]"
-    description: The name given to your package. This should be available on package indexing sites (PyPI/Anaconda). Typically, it is the same as the `module_name`, but if your preferred package name is already taken online, you should rename your project entirely or prepend the package name with e.g. `arup-`. For example, our PAM package is `pam` when imported in Python, but `cml-pam` online.
+    description: >-
+      The name given to your package. This should be available on package indexing sites (PyPI/Anaconda).
+      Typically, it is the same as the `module_name`, but if your preferred package name is already taken online, you should rename your project entirely or prepend the package name with e.g. `arup-`.
+      For example, our PAM package is `pam` when imported in Python, but `cml-pam` online.
+
   module_name:
     type: string
     default: "[repository_name]"
-    description: The name given to your module in Python. This should be available on package indexing sites (PyPI/Anaconda). Typically, it is the same as the `package_name`, assuming your preferred package name is available online. This is what users will call when importing your module in Python (e.g. `import pam`, even though the package name is `cml-pam`) or when calling your package from the command line (if you have a command line interface).
+    description: >-
+      The name given to your module in Python.
+      This should be available on package indexing sites (PyPI/Anaconda).
+      Typically, it is the same as the `package_name`, assuming your preferred package name is available online.
+      This is what users will call when importing your module in Python (e.g. `import pam`, even though the package name is `cml-pam`) or when calling your package from the command line (if you have a command line interface).
+
   project_short_description:
     type: string
     default: "Python Boilerplate contains all the boilerplate you need to create a Python package."
@@ -62,14 +85,11 @@ properties:
     default: "[github_username]"
     description: Your anaconda channel, if releases of your package will be uploaded to Anaconda.
 
-  version:
-    type: string
-    default: "0.1.0"
-    description: The starting version number of the package.
-
   create_jupyter_notebook_directory:
     type: array
-    description: If "y", an `examples` directory will be created in which Jupyter Notebooks can be saved. These notebooks will be rendered in the documentation and will be formatted with Black and Ruff.
+    description: >-
+      If "y", an `examples` directory will be created in which Jupyter Notebooks can be saved.
+      These notebooks will be rendered in the documentation and will be formatted with Black and Ruff.
     uniqueItems: true
     minItems: 1
     items: &y_n_items

--- a/{{cookiecutter.repository_name}}/.github/workflows/pre-release.yml
+++ b/{{cookiecutter.repository_name}}/.github/workflows/pre-release.yml
@@ -13,8 +13,9 @@ jobs:
       ANACONDA_TOKEN: {% raw %}${{ secrets.ANACONDA_TOKEN }}{% endraw %}
     with:
       package_name: {{ cookiecutter.package_name }}
-  {% endif %}
+      environment: pre-release
 
+  {% endif %}
   {% if cookiecutter.upload_pypi_package|lower == 'y' -%}
   pip-build:
     uses: arup-group/actions-city-modelling-lab/.github/workflows/pip-build.yml@main
@@ -22,4 +23,6 @@ jobs:
       TEST_PYPI_API_TOKEN: {% raw %}${{ secrets.TEST_PYPI_API_TOKEN }}{% endraw %}
     with:
       package_name: {{ cookiecutter.package_name }}
+      environment: pre-release
+
   {% endif %}

--- a/{{cookiecutter.repository_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.repository_name}}/.github/workflows/release.yml
@@ -13,8 +13,9 @@ jobs:
     with:
       package_name: {{ cookiecutter.package_name }}
       build_workflow: pre-release.yml
-  {% endif %}
+      environment: release
 
+  {% endif %}
   {% if cookiecutter.upload_pypi_package|lower == 'y' -%}
   pip-upload:
     uses: arup-group/actions-city-modelling-lab/.github/workflows/pip-upload.yml@main
@@ -23,8 +24,9 @@ jobs:
     with:
       package_name: {{ cookiecutter.package_name }}
       build_workflow: pre-release.yml
-  {% endif %}
+      environment: release
 
+  {% endif %}
   docs-stable:
     permissions:
       contents: write

--- a/{{cookiecutter.repository_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repository_name}}/.pre-commit-config.yaml
@@ -9,19 +9,19 @@ repos:
         args: ["--maxkb=1000"]
 
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 24.2.0
     hooks:
       - id: black
 
   - repo: https://github.com/astral-sh/ruff-pre-commit  # https://beta.ruff.rs/docs/usage/#github-action
-    rev: v0.0.282
+    rev: v0.2.2
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
 
 {%- if cookiecutter.create_jupyter_notebook_directory|lower == "y" %}
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.7.0
+    rev: 1.7.1
     hooks:
       - id: nbqa-black
       - id: nbqa-ruff

--- a/{{cookiecutter.repository_name}}/CHANGELOG.md
+++ b/{{cookiecutter.repository_name}}/CHANGELOG.md
@@ -7,6 +7,9 @@ Deprecated: for soon-to-be removed features.
 Removed: for now removed features.
 Fixed: for any bug fixes.
 Security: in case of vulnerabilities.
+
+Release headings should be of the form:
+## [X.Y.Z] - YEAR-MONTH-DAY
 -->
 
 # Changelog
@@ -25,9 +28,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Removed
-
-## [v{{ cookiecutter.version }}] - {% now 'utc', '%Y-%m-%d' %}
-
-Initial release.
-
-[unreleased]: https://github.com/{{ cookiecutter.repository_owner }}/{{ cookiecutter.repository_name }}/compare/v{{ cookiecutter.version }}...main

--- a/{{cookiecutter.repository_name}}/CONTRIBUTING.md
+++ b/{{cookiecutter.repository_name}}/CONTRIBUTING.md
@@ -93,7 +93,7 @@ When adding docstrings, we request you use the [Google docstring style](https://
 ### Create release
 
 - [ ] Bump the version number in `src/{{ cookiecutter.module_name }}/__init__.py`
-- [ ] Update the [changelog][changelog] with final version number of the form `vX.Y.Z`, release date, and github `compare` link (at the bottom of the page).
+- [ ] Update the [changelog][changelog] with final version number of the form `vX.Y.Z`, release date, and [github `compare` link](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/viewing-and-comparing-commits/comparing-commits) (at the bottom of the page).
 - [ ] Commit with message `Release vX.Y.Z`, then add a `vX.Y.Z` tag.
 - [ ] Create a release pull request to verify that the conda package builds successfully.
 - [ ] Once the PR is approved and merged, create a release through the GitHub web interface, using the same tag, titling it `Release vX.Y.Z` and include all the changelog elements that are *not* flagged as **internal**.

--- a/{{cookiecutter.repository_name}}/README.md
+++ b/{{cookiecutter.repository_name}}/README.md
@@ -82,7 +82,6 @@ mike serve
 
 Then you can view the documentation in a browser at http://localhost:8000/.
 
-
 ## Credits
 
 This package was created with [Cookiecutter](https://github.com/audreyr/cookiecutter) and the [arup-group/cookiecutter-pypackage](https://github.com/arup-group/cookiecutter-pypackage) project template.

--- a/{{cookiecutter.repository_name}}/docs/contributing.md
+++ b/{{cookiecutter.repository_name}}/docs/contributing.md
@@ -63,6 +63,7 @@ You can also run these checks yourself at any time to ensure staged changes are 
 {%- endif %}
 
 ### Rapid-fire testing
+
 The following options allow you to strip down the test suite to the bare essentials:
 
 {%- if cookiecutter.create_jupyter_notebook_directory|lower == "y" %}
@@ -106,6 +107,13 @@ memray flamegraph [my_path]/[my_prefix]-tests-test_100_memory_profiling.py-test_
 ```
 
 For more information on using memray, refer to their [documentation](https://bloomberg.github.io/memray/index.html).
+
+## Updating the project when the template updates
+
+This project has been built with [cruft](https://cruft.github.io/cruft/) based on the [Arup Cookiecutter template](https://github.com/arup-group/cookiecutter-pypackage).
+When changes are made to the base template, they can be merged into this project by running `cruft update` from the  `{{ cookiecutter.repository_name }}` mamba environment.
+
+You may be prompted to do this when you open a Pull Request, if our automated checks identify that the template is newer than that used in the project.
 
 ## Submitting changes
 

--- a/{{cookiecutter.repository_name}}/docs/static/hooks.py
+++ b/{{cookiecutter.repository_name}}/docs/static/hooks.py
@@ -20,8 +20,7 @@ def on_files(files: list, config: dict, **kwargs):
     {%- if cookiecutter.create_jupyter_notebook_directory|lower == "y" %}
     for file in sorted(Path("./examples").glob("*.ipynb")):
         files.append(_new_file(file, config))
-        nav_reference = [idx for idx in config["nav"] if set(idx.keys()) == {"Examples"}][0]
-        nav_reference["Examples"].append(file.as_posix())
+        _get_nav_list(config["nav"], "Examples").append(file.as_posix())
     {%- endif %}
     for file in Path("./resources").glob("**/*.*"):
         files.append(_new_file(file, config))
@@ -124,9 +123,27 @@ def _update_nav(api_nav: dict, config: dict) -> None:
     api_reference_nav = {
         "Python API": [*api_nav.pop("top_level"), *[{k: v} for k, v in api_nav.items()]]
     }
-    nav_reference = [idx for idx in config["nav"] if set(idx.keys()) == {"Reference"}][0]
-    nav_reference["Reference"].append(api_reference_nav)
+    _get_nav_list(config["nav"], "Reference").append(api_reference_nav)
 
+
+def _get_nav_list(nav: list[dict | str], ref: str) -> list:
+    """Get navigation entry sub-page list.
+    Navigation list entries can be dictionaries or strings.
+    Sub-list entries can then also be dictionaries or strings. E.g.,
+
+    ```python
+    [{"Page Title": ["sub-page-1", {"Sub-Page-2 Title": "sub-page-2"}, ...], ...}]
+    ```
+
+    Args:
+        nav (list[dict  |  str]): MKdocs `nav` config entry.
+        ref (str): Page title reference to return the sub-list of.
+
+    Returns:
+        list: Nav sub-list linked to `ref`.
+    """
+    nav_ref = [idx for idx in nav if isinstance(idx, dict) and set(idx.keys()) == {ref}][0]
+    return nav_ref[ref]
 
 @mkdocs.plugins.event_priority(-100)
 def on_post_build(**kwargs):

--- a/{{cookiecutter.repository_name}}/mkdocs.yml
+++ b/{{cookiecutter.repository_name}}/mkdocs.yml
@@ -18,6 +18,9 @@ theme:
   custom_dir: docs/overrides
   features:
     - navigation.indexes
+    - navigation.top
+    - content.code.copy
+    - content.code.annotate
 repo_url: https://github.com/{{ cookiecutter.repository_owner }}/{{ cookiecutter.repository_name }}/
 site_dir: .docs
 markdown_extensions:
@@ -36,6 +39,8 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.superfences
   - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.tasklist:
       clickable_checkbox: true
   - toc:
@@ -44,6 +49,7 @@ markdown_extensions:
 hooks:
   - docs/static/hooks.py
 plugins:
+  - search
   - autorefs
 {%- if cookiecutter.create_jupyter_notebook_directory|lower == "y" %}
   - mkdocs-jupyter:
@@ -70,7 +76,6 @@ plugins:
           paths: [src]
           import:
             - https://docs.python.org/3/objects.inv
-  - search
 watch:
   - src/{{ cookiecutter.module_name }}
 extra_css:

--- a/{{cookiecutter.repository_name}}/requirements/dev.txt
+++ b/{{cookiecutter.repository_name}}/requirements/dev.txt
@@ -1,3 +1,4 @@
+cruft >= 2, < 3
 {% if cookiecutter.create_jupyter_notebook_directory|lower == "y" -%}
 jupyter < 2
 {% endif -%}

--- a/{{cookiecutter.repository_name}}/src/{{cookiecutter.module_name}}/__init__.py
+++ b/{{cookiecutter.repository_name}}/src/{{cookiecutter.module_name}}/__init__.py
@@ -1,5 +1,5 @@
 """Top-level module for {{ cookiecutter.module_name }}."""
 
-__author__ = "{{ cookiecutter.full_name }}"
+__author__ = """{{ cookiecutter.full_name }}"""  # triple quotes in case the name has quotes in it.
 __email__ = "{{ cookiecutter.email }}"
 __version__ = "0.1.0.dev0"

--- a/{{cookiecutter.repository_name}}/src/{{cookiecutter.module_name}}/__init__.py
+++ b/{{cookiecutter.repository_name}}/src/{{cookiecutter.module_name}}/__init__.py
@@ -1,5 +1,5 @@
 """Top-level module for {{ cookiecutter.module_name }}."""
 
-__author__ = """{{ cookiecutter.full_name }}"""
+__author__ = "{{ cookiecutter.full_name }}"
 __email__ = "{{ cookiecutter.email }}"
-__version__ = "{{ cookiecutter.version }}"
+__version__ = "0.1.0.dev0"


### PR DESCRIPTION
Collection of different fixes based on learning from updating https://github.com/arup-group/freightpop and https://github.com/arup-group/gtfs_skims:

1. Removed "version" from template input. This was supposed to set the initial version, but doesn't really work because then if you update your project from the template it will try to revert whatever version you're now on to the initial version...
2. Updated release CI and docs to match changes made in https://github.com/arup-group/actions-city-modelling-lab/pull/17
3.  Added docs section to template on updating with Cruft, and added Cruft to the development dependencies so that a user can update their project without needing to switch to their cookiecutter mamba environment (which doesn't have pre-commit installed, so you might commit unexpected things).