### PR TITLE
Move py.typed into source code dir

### DIFF
--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -47,6 +47,13 @@ def test_bake_with_defaults_top_level_files(default_bake):
     ]
 
 
+def test_bake_with_defaults_src_code_files(default_bake):
+    found_src_code_files = [
+        i.name for i in (default_bake.project_path / "src" / "python_boilerplate").iterdir()
+    ]
+    assert set(found_src_code_files) == {"py.typed", "__init__.py", "core.py", "cli.py"}
+
+
 def test_bake_withspecialchars_and_run_tests(cookies, install_baked):
     """Ensure that a `full_name` with double quotes does not break setup.py"""
     result = cookies.bake(extra_context={"full_name": 'name "quote" name'})

--- a/{{cookiecutter.repository_name}}/pyproject.toml
+++ b/{{cookiecutter.repository_name}}/pyproject.toml
@@ -99,7 +99,8 @@ where = ["src"]
 [tool.setuptools.package-data]
 # Add file globs from the source code directory if they include non-py files that should be packaged
 # E.g. "fixtures/**/*"
-{{ cookiecutter.module_name }} = []
+# "py.typed" is added by default. It allows `mypy` to register the package as having type hints.
+{{ cookiecutter.module_name }} = ["py.typed"]
 
 
 [build-system]


### PR DESCRIPTION
Didn't get this right the first time. Have now moved `py.typed` into the source code and referenced it in `pyproject.toml` so that it is captured when the package wheel is built.
