### PR TITLE
Add src ref to conda build recipe

### DIFF
--- a/{{cookiecutter.repository_name}}/conda.recipe/meta.yaml
+++ b/{{cookiecutter.repository_name}}/conda.recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% raw %}{% set pyproject = load_file_data('../pyproject.toml', from_recipe_dir=True) %}
-{% set version = load_file_regex(load_file='../{% endraw %}{{ cookiecutter.module_name }}{% raw %}/__init__.py', regex_pattern="__version__ = \"([a-zA-Z0-9\.].*?)\"", from_recipe_dir=True) %}
+{% set version = load_file_regex(load_file='../src/{% endraw %}{{ cookiecutter.module_name }}{% raw %}/__init__.py', regex_pattern="__version__ = \"([a-zA-Z0-9\.].*?)\"", from_recipe_dir=True) %}
 {% set requirements = load_file_regex(load_file='../requirements/base.txt', regex_pattern="", from_recipe_dir=True) %}
 {% set requirements_dev = load_file_regex(load_file='../requirements/dev.txt', regex_pattern="", from_recipe_dir=True) %}
 
@@ -47,7 +47,7 @@ test:
     - {{ dep.lower().replace(" ", "") }}
     {% endfor %}
   commands:
-    - pytest --cov-reset --cov={% endraw %}{{ cookiecutter.module_name }}{% raw %} tests/
+    - pytest --no-cov tests/
 
 
 about:


### PR DESCRIPTION
Difficult one to test, but I was [linking genet to the template](https://github.com/arup-group/genet/pull/234) and found this issue. 

I also decided to not include coverage checks in the built conda package tests as it can easily fall below the threshold due to skipped tests (in the case of genet, because coin-or-cbc is not included in the dependencies so those tests are skipped).