### PR TITLE
Pin mkdocs to <v1.6

### DIFF
--- a/{{cookiecutter.repository_name}}/requirements/dev.txt
+++ b/{{cookiecutter.repository_name}}/requirements/dev.txt
@@ -3,7 +3,7 @@ cruft >= 2, < 3
 jupyter < 2
 {% endif -%}
 mike >= 2, < 3
-mkdocs < 2
+mkdocs < 1.6
 mkdocs-material >= 9.4, < 10
 {% if cookiecutter.command_line_interface|lower == "y" -%}
 mkdocs-click < 0.7

--- a/{{cookiecutter.repository_name}}/requirements/dev.txt
+++ b/{{cookiecutter.repository_name}}/requirements/dev.txt
@@ -9,7 +9,7 @@ mkdocs-material >= 9.4, < 10
 mkdocs-click < 0.7
 {% endif -%}
 {% if cookiecutter.create_jupyter_notebook_directory|lower == "y" -%}
-mkdocs-jupyter < 0.25
+mkdocs-jupyter < 0.24.7
 {% endif -%}
 mkdocstrings-python < 2
 {% if cookiecutter.create_jupyter_notebook_directory|lower == "y" -%}


### PR DESCRIPTION
Latest version of `mkdocs` is incompatible with `mkdocs-jupyter` < v.024.7 but v0.24.7 conda forge pacakge is broken due to a PyPI issue (see [here](https://github.com/danielfrg/mkdocs-jupyter/issues/197)). This breaks our docs builds.

Current plan: limit `mkdocs` version. 
Future aim: update to latest `mkdocs` and `mkdocs-jupyter` when v 0.24.7 is available.