### PR TITLE
Auto thread selection on calling pytest

### DIFF
--- a/{{cookiecutter.repository_name}}/docs/contributing.md
+++ b/{{cookiecutter.repository_name}}/docs/contributing.md
@@ -71,17 +71,6 @@ The following options allow you to strip down the test suite to the bare essenti
 The integration tests can be slow, so if you want to avoid them during development, you should run `pytest tests/`.
 {%- endif %}
 1. You can avoid generating coverage reports, by adding the `--no-cov` argument: `pytest --no-cov`.
-1. By default, the tests run with up to two parallel threads, to increase this to e.g. 4 threads: `pytest -n4`.
-
-All together:
-
-``` shell
-pytest tests/ --no-cov -n4
-```
-
-!!! note
-
-    You cannot debug failing tests and have your tests run in parallel, you will need to set `-n0` if using the `--pdb` flag
 
 ### Memory profiling
 

--- a/{{cookiecutter.repository_name}}/pyproject.toml
+++ b/{{cookiecutter.repository_name}}/pyproject.toml
@@ -25,10 +25,10 @@ minversion = "6.0"
 # `-m 'not high_mem'` - Do not run tests marked as consuming large amounts of memory (call `-m "high_mem"` in CLI to invert this; only `high_mem` marked tests will be run)
 # `-p no:memray` - Do not use the memray memory profiling plugin (call `-p memray` in CLI to switch on memory profiling)
 {%- if cookiecutter.create_jupyter_notebook_directory|lower == "y" %}
-addopts = "-rav --strict-markers -n2 --nbmake --nbmake-kernel={{ cookiecutter.repository_name }} --cov --cov-report=xml --cov-config=pyproject.toml -m 'not high_mem' -p no:memray"
+addopts = "-rav --strict-markers -nauto --nbmake --nbmake-kernel={{ cookiecutter.repository_name }} --cov --cov-report=xml --cov-config=pyproject.toml -m 'not high_mem' -p no:memray"
 testpaths = ["tests", "examples"]
 {% else %}
-addopts = "-rav --strict-markers -n2 --cov --cov-report=xml --cov-config=pyproject.toml -m 'not high_mem' -p no:memray"
+addopts = "-rav --strict-markers -nauto --cov --cov-report=xml --cov-config=pyproject.toml -m 'not high_mem' -p no:memray"
 testpaths = ["tests"]
 {%- endif %}
 # to mark a test, decorate it with `@pytest.mark.[marker-name]`


### PR DESCRIPTION
Simplifies multi-threaded testing by using as many cores are available. It will also automatically limit to one thread when debugging (using the pytest `--pdb` arg) which is neat.