### PR TITLE
Add editorconfig; add ruff-format to pre-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- EditorConfig file within template (#50).
 - Documentation accessibility checking (#41).
 - Documentation FAQ in contributing guidelines (#41).
 
 ### Fixed
 
+- Missing Ruff formatting step in pre-commit config (#51).
 - Template documentation in light of accessibility issues of some features (namely, mkdocs-material annotations and task lists, and mkdocs-jupyter codeblock highlighting) (#41).
 - Triggering of CI linting and codecov upload for internal (i.e. not open-source) projects (#44).
 

--- a/{{cookiecutter.repository_name}}/.editorconfig
+++ b/{{cookiecutter.repository_name}}/.editorconfig
@@ -1,0 +1,18 @@
+# Documentation: https://EditorConfig.org
+# Inspired by Calliope .editorconfig file
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.{yaml,yml}]
+indent_size = 2
+
+[LICENSE]
+insert_final_newline = false

--- a/{{cookiecutter.repository_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repository_name}}/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
+      - id: ruff-format
 
   - repo: local
     hooks:

--- a/{{cookiecutter.repository_name}}/src/{{cookiecutter.module_name}}/cli.py
+++ b/{{cookiecutter.repository_name}}/src/{{cookiecutter.module_name}}/cli.py
@@ -7,8 +7,6 @@ import click
 @click.command()
 def cli(args=None):
     """Console script for {{cookiecutter.module_name}}."""
-    click.echo(
-        "Replace this message by putting your code into {{cookiecutter.module_name}}.cli.cli"
-    )
+    click.echo("Replace this message by putting your code into {{cookiecutter.module_name}}.cli.cli")
     click.echo("See click documentation at https://click.palletsprojects.com/")
     return 0

--- a/{{cookiecutter.repository_name}}/tests/test_cli.py
+++ b/{{cookiecutter.repository_name}}/tests/test_cli.py
@@ -16,6 +16,5 @@ def test_command_line_interface():
     assert (
         "Console script for {{ cookiecutter.module_name }}.\n\nOptions:\n  "
         "--version  Show the version and exit.\n  "
-        "--help     Show this message and exit.\n"
-        in help_result.output
+        "--help     Show this message and exit.\n" in help_result.output
     )


### PR DESCRIPTION
Fixes #50 
Adds missing Ruff formatter rule to the pre-commit config (since formatting was moved from Black to Ruff in #43) 