### PR TITLE
Add cookiecutter prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Human-readable prompts when baking a project (#56).
 - EditorConfig file within template (#50).
 - Documentation accessibility checking (#41).
 - Documentation FAQ in contributing guidelines (#41).

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -48,5 +48,59 @@
     "ISC license",
     "Apache Software License 2.0",
     "GNU General Public License v3"
-  ]
+  ],
+
+  "__prompts__": {
+    "full_name": "[bold yellow](full_name)[/bold yellow] Your full name.",
+    "email": "[bold yellow](email)[/bold yellow] Your email address. Use the same one as you use on GitHub.",
+    "github_username": "[bold yellow](github_username)[/bold yellow] Your GitHub username.",
+    "project_title": "[bold yellow](project_title)[/bold yellow] The headline name of your new Python package project. [italic red]NOTE:[/italic red] this is used in documentation, so spaces and any characters are fine here.",
+    "repository_owner": "[bold yellow](repository_owner)[/bold yellow] The owner of your GitHub repository (i.e., https://github.com/[repository_owner]). [italic red]NOTE:[/italic red] for personal projects, this can be your GitHub username. For Arup projects, this should be `arup-group`.",
+    "repository_name": "[bold yellow](repository_name)[/bold yellow] Name of the github repository where you will host your project (i.e., https://github.com/[repository_owner]/[repository_name]). [italic red]NOTE:[/italic red] typically, it is the 'slugified' version of `project_title` (e.g. `My software package` -> `my_software_package`) or an abbreviation derived from it (e.g., `Population Activity Modeller` -> `pam`).",
+    "package_name": "[bold yellow](package_name)[/bold yellow] The name given to your package. This should be available on package indexing sites (PyPI/Anaconda). [italic red]NOTE:[/italic red] typically, it is the same as the `module_name`, but if your preferred package name is already taken online, you should rename your project entirely or prepend the package name with e.g. `arup-`. For example, our PAM package is `pam` when imported in Python, but `cml-pam` online.",
+    "module_name": "[bold yellow](module_name)[/bold yellow] The name given to your module in Python. This should be available on package indexing sites (PyPI/Anaconda). [italic red]NOTE:[/italic red] typically, it is the same as the `package_name`, assuming your preferred package name is available online. This is what users will call when importing your module in Python (e.g. `import pam`, even though the package name is `cml-pam`) or when calling your package from the command line (if you have a command line interface).",
+    "project_short_description": "[bold yellow](project_short_description)[/bold yellow] A 1-sentence description of what your Python package does.",
+    "upload_pypi_package": {
+        "__prompt__": "[bold yellow](upload_pypi_package)[/bold yellow] Upload pip package to PyPI (public projects) or the Arup package index (internal projects) on each release of each new version?",
+        "y": "Yes",
+        "n": "No"
+    },
+    "upload_conda_package":  {
+        "__prompt__": "[bold yellow](upload_conda_package)[/bold yellow] Upload conda package to an Anaconda channel on each release of a new version?",
+        "y": "Yes",
+        "n": "No"
+    },
+    "upload_aws_image": {
+        "__prompt__": "[bold yellow](upload_aws_image)[/bold yellow] Upload the repository to AWS to build and host a Docker image of the project on each commit? [italic red]NOTE:[/italic red] requires CodeBuild configuration to be updated separately to have the image built on AWS.",
+        "y": "Yes",
+        "n": "No"
+    },
+    "conda_channel": "[bold yellow](conda_channel)[/bold yellow] Your channel for conda uploads. [italic red]NOTE:[/italic red] if releases of your package will be uploaded to Anaconda it should link to https://anaconda.org/[conda_channel]. If the project visibility is 'internal' this parameter must be https://packages.arup.com/conda",
+    "create_jupyter_notebook_directory": {
+        "__prompt__": "[bold yellow](create_jupyter_notebook_directory)[/bold yellow] Add an `examples` directory in which Jupyter Notebooks can be saved? These notebooks will be rendered in the documentation and will be formatted with Ruff.",
+        "y": "Yes",
+        "n": "No"
+    },
+    "check_docs_accessibility_in_CI": {
+        "__prompt__": "[bold yellow](check_docs_accessibility_in_CI)[/bold yellow] Check documentation for accessibility, according to the WCAG2AA standard, in Pull Request CI?",
+        "y": "Yes",
+        "n": "No"
+    },
+    "command_line_interface":{
+        "__prompt__": "[bold yellow](command_line_interface)[/bold yellow] Provide a Command Line Interface for your module?",
+        "y": "Yes",
+        "n": "No"
+    },
+    "create_author_file": {
+        "__prompt__": "[bold yellow](create_author_file)[/bold yellow] Create an AUTHORS file to log multiple project authors?",
+        "y": "Yes",
+        "n": "No"
+    },
+    "create_docker_file":{
+        "__prompt__": "[bold yellow](create_docker_file)[/bold yellow] Create a Dockerfile which allows a Docker image of the project to be built in a linux virtual machine with a basic Bash entry-point?",
+        "y": "Yes",
+        "n": "No"
+    },
+    "open_source_license": "[bold yellow](open_source_license)[/bold yellow] Choose a license for your project."
+  }
 }

--- a/docs/static/hooks.py
+++ b/docs/static/hooks.py
@@ -1,3 +1,4 @@
+"""Hooks for creating docs pages on-the-fly."""
 import tempfile
 from pathlib import Path
 
@@ -9,10 +10,19 @@ from mkdocs.structure.files import File
 TEMPDIR = tempfile.TemporaryDirectory()
 
 
-def on_files(files: list, config: dict, **kwargs):
-    """
+def on_files(files: list, config: dict, **kwargs) -> list:
+    """Update MKDocs pages.
+
     1. Link top-level files to mkdocs files.
     2. Clean up YAML schema
+
+    Args:
+        files (list): List of MKDocs project files.
+        config (dict): MKDocs project configuration.
+        **kwargs: necessary to capture inputs provided by MKDocs when it calls this function.
+
+    Returns:
+        list: Updated list of MKDocs project files.
     """
     files.append(_new_file("./CHANGELOG.md", config))
     files.append(_new_file("./CONTRIBUTING.md", config))
@@ -27,12 +37,21 @@ def on_post_build(**kwargs):
     """After mkdocs has finished building the docs, remove the temporary directory of markdown files.
 
     Args:
-        config (Config): mkdocs config dictionary (unused).
+        **kwargs (Config): mkdocs config dictionary (unused).
     """
     TEMPDIR.cleanup()
 
 
 def _new_file(path: str | Path, config: dict) -> File:
+    """Create an MKDocs File object.
+
+    Args:
+        path (str | Path): Path to file.
+        config (dict): MKDocs project configuration.
+
+    Returns:
+        File: File object.
+    """
     return File(
         path=path,
         src_dir=".",
@@ -41,15 +60,22 @@ def _new_file(path: str | Path, config: dict) -> File:
     )
 
 
-def _schema2md(config: dict):
-    """Generate overview over configuration schema and add to mkdoc's files."""
+def _schema2md(config: dict) -> File:
+    """Generate overview over configuration schema and add to mkdoc's files.
+
+    Args:
+        config (dict): MKDocs project configuration.
+
+    Returns:
+        File: File object.
+    """
     path_to_schema: Path = Path.cwd() / "schema.yaml"
     path_to_md: Path = Path(TEMPDIR.name) / "schema.md"
 
     parser = jsonschema2md.Parser()
     parser.tab_size = 4
     schema = yaml.safe_load(path_to_schema.read_text())
-
+    schema.pop("__prompts__")
     lines = parser.parse_schema(schema)
     lines = _customise_markdown(lines)
 
@@ -64,6 +90,14 @@ def _schema2md(config: dict):
 
 
 def _customise_markdown(lines: list) -> list:
+    """Clean up rendered Schema so that it doesn't read as a schema in the docs.
+
+    Args:
+        lines (list): rendered schema as a list of line strings
+
+    Returns:
+        list: Cleaned, rendered schema as a list of line strings
+    """
     # 1. Change headline
     assert lines[0] == "# JSON Schema\n\n"
     lines[0] = "# Configuration values\n\n"

--- a/schema.yaml
+++ b/schema.yaml
@@ -151,3 +151,7 @@ properties:
         - Apache Software License 2.0
         - GNU General Public License v3
         - Not open source
+
+  __prompts__:
+    type: object
+    description: Long descriptions for all properties.


### PR DESCRIPTION
Fixes #56 

Some of the prompts can be a bit long. Could slim down some of the longer notes, but I'm not sure which. It renders as:

![image](https://github.com/user-attachments/assets/a41b2d58-2133-4d38-8c21-b170010cbd77)

