### PR TITLE
Pass actual test job result onto Slack notifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Pass test result status correctly to slack notification CI action.
 - Missing Ruff formatting step in pre-commit config (#51).
 - Template documentation in light of accessibility issues of some features (namely, mkdocs-material annotations and task lists, and mkdocs-jupyter codeblock highlighting) (#41).
 - Triggering of CI linting and codecov upload for internal (i.e. not open-source) projects (#44).

--- a/{{cookiecutter.repository_name}}/.github/workflows/daily-scheduled-ci.yml
+++ b/{{cookiecutter.repository_name}}/.github/workflows/daily-scheduled-ci.yml
@@ -32,6 +32,6 @@ jobs:
     secrets:
       SLACK_WEBHOOK: {% raw %}${{ secrets.SLACK_WEBHOOK }}{% endraw %}
     with:
-      result: needs.test.result
+      result: {% raw %}${{ needs.test.result }}{% endraw %}
       channel: {{ cookiecutter.repository_name }}-feed
       message: Daily CI action


### PR DESCRIPTION
Noticed in a failing daily CI job that wasn't passing the message onto Slack. 

You can avoid using `${{ ... }}` in github actions for calls in `if:` statements. Everywhere else, you need to enclose the call in `${{ ... }}` otherwise it will be taken as a literal string. 