### PR TITLE
Update authors & license references

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -8,6 +8,7 @@ on:
       - README.md
       - CHANGELOG.md
       - LICENSE
+      - AUTHORS.md
       - CONTRIBUTING.md
       - docs/**
       - mkdocs.yml

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -8,6 +8,7 @@ on:
       - README.md
       - CHANGELOG.md
       - LICENSE
+      - AUTHORS.md
       - CONTRIBUTING.md
       - docs/**
       - mkdocs.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix, --config, pyproject.toml ]
       - id: ruff-format
+        args: [ --config, pyproject.toml ]
 
 ci:  # https://pre-commit.ci/
   autofix_prs: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ This is now captured by a pre-commit hook.
 
 ### Changed
 
+- Reference to authors in license files/sections.
+- `AUTHORS.md` defaults to _not_ being created when baking a project.
 - `upload_pypi_package` -> `upload_pip_package`.
 - Recommend `conda` instead of `mamba` for project creation and package installation (#53).
 - Docs CI run on PR to main or on main, with different jobs run in each case (#33).
@@ -46,6 +48,10 @@ This is now captured by a pre-commit hook.
 - Move to exclusively using `ruff` for code formatting and linting; update to `ruff` version 0.6 (#43).
 - Cookiecutter config set to have no license for the repository (i.e. internal IP) by default.
 - Make upload and build of Docker image on AWS optional (#42).
+
+### Removed
+
+- Reference to authors removed from `src/<module-name>/__init__.py`. Authors now limited to `pyproject.toml` and - optionally - `AUTHORS.md`.
 
 ## [v0.2.0] - 09-01-2024
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -31,8 +31,8 @@
     "n"
   ],
   "create_author_file": [
-    "y",
-    "n"
+    "n",
+    "y"
   ],
   "create_jupyter_notebook_directory": [
     "y",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
         file_to_delete.unlink()
 
     if "{{ cookiecutter.create_author_file|lower }}" == "n":
-        remove_file("AUTHORS")
+        remove_file("AUTHORS.md")
 
     if "{{ cookiecutter.command_line_interface|lower }}" == "n":
         for file in [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ skip-magic-trailing-comma = true
 quote-style = "double"
 indent-style = "space"
 line-ending = "auto"
+exclude = ["\\{\\{cookiecutter.repository_name\\}}\\}}"]
 
 [tool.ruff.lint]
 select = [

--- a/schema.yaml
+++ b/schema.yaml
@@ -127,7 +127,7 @@ properties:
     description: If "y", create an authors file.
     uniqueItems: true
     minItems: 1
-    items: *y_n_items
+    items: *n_y_items
 
   create_docker_file:
     type: array

--- a/{{cookiecutter.repository_name}}/AUTHORS.md
+++ b/{{cookiecutter.repository_name}}/AUTHORS.md
@@ -1,13 +1,9 @@
-=======
-Credits
-=======
+# Credits
 
-Development Lead
-----------------
+## Development Lead
 
 * {{ cookiecutter.full_name }} <{{ cookiecutter.email }}>
 
-Contributors
-------------
+## Contributors
 
 None yet. Why not be the first?

--- a/{{cookiecutter.repository_name}}/CONTRIBUTING.md
+++ b/{{cookiecutter.repository_name}}/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Some of the resources to look at if you're interested in contributing:
 
 ## Licensing
 
+Copyright (c) {% now 'local', '%Y' %} {% if cookiecutter.repository_owner == "arup-group" %}Arup{% elif cookiecutter.create_author_file == "y" %}{{ cookiecutter.package_name }} developers & contributors listed in AUTHORS.md{% else %}{{ cookiecutter.full_name }}{% endif %}.
 {%- if cookiecutter.open_source_license == "Not open source" %}
 This repository is not open source.
 You will need explicit permission from the repository owner to redistribute or make any modifications to this code.
@@ -46,6 +47,10 @@ To contribute changes:
 1. Push the branch to GitHub (`git push origin new-fix-or-feature`).
 1. On GitHub, create a new [pull request](https://github.com/{{ cookiecutter.repository_owner }}/{{ cookiecutter.repository_name }}/pull/new/main) from the feature branch.
 
+{%- if cookiecutter.create_author_file == "y" %}
+When you contribute for the first time, ensure you add your name to the contributors list in `AUTHORS.md`!
+
+{%- endif %}
 ### Pull requests
 
 Before submitting a pull request, check whether you have:

--- a/{{cookiecutter.repository_name}}/LICENSE
+++ b/{{cookiecutter.repository_name}}/LICENSE
@@ -1,7 +1,7 @@
 {% if cookiecutter.open_source_license == 'MIT license' -%}
 MIT License
 
-Copyright (c) {% now 'local', '%Y' %} {% if cookiecutter.repository_owner == "arup-group" %}Arup{% else %}{{ cookiecutter.full_name }}{% endif %}
+Copyright (c) {% now 'local', '%Y' %} {% if cookiecutter.repository_owner == "arup-group" %}Arup{% elif cookiecutter.create_author_file == "y" %}{{ cookiecutter.package_name }} developers & contributors listed in AUTHORS.md{% else %}{{ cookiecutter.full_name }}{% endif %}.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -20,11 +20,11 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-{% elif cookiecutter.open_source_license == 'BSD license' %}
 
+{%- elif cookiecutter.open_source_license == 'BSD license' -%}
 BSD License
 
-Copyright (c) {% now 'local', '%Y' %} {% if cookiecutter.repository_owner == "arup-group" %}Arup{% else %}{{ cookiecutter.full_name }}{% endif %}
+Copyright (c) {% now 'local', '%Y' %} {% if cookiecutter.repository_owner == "arup-group" %}Arup{% elif cookiecutter.create_author_file == "y" %}{{ cookiecutter.package_name }} developers & contributors listed in AUTHORS.md{% else %}{{ cookiecutter.full_name }}{% endif %}.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
@@ -51,18 +51,20 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
 OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 OF THE POSSIBILITY OF SUCH DAMAGE.
-{% elif cookiecutter.open_source_license == 'ISC license' -%}
+
+{%- elif cookiecutter.open_source_license == 'ISC license' -%}
 ISC License
 
-Copyright (c) {% now 'local', '%Y' %} {% if cookiecutter.repository_owner == "arup-group" %}Arup{% else %}{{ cookiecutter.full_name }}{% endif %}
+Copyright (c) {% now 'local', '%Y' %} {% if cookiecutter.repository_owner == "arup-group" %}Arup{% elif cookiecutter.create_author_file == "y" %}{{ cookiecutter.package_name }} developers & contributors listed in AUTHORS.md{% else %}{{ cookiecutter.full_name }}{% endif %}.
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-{% elif cookiecutter.open_source_license == 'Apache Software License 2.0' -%}
+
+{%- elif cookiecutter.open_source_license == 'Apache Software License 2.0' -%}
 Apache Software License 2.0
 
-Copyright (c) {% now 'local', '%Y' %} {% if cookiecutter.repository_owner == "arup-group" %}Arup{% else %}{{ cookiecutter.full_name }}{% endif %}
+Copyright (c) {% now 'local', '%Y' %} {% if cookiecutter.repository_owner == "arup-group" %}Arup{% elif cookiecutter.create_author_file == "y" %}{{ cookiecutter.package_name }} developers & contributors listed in AUTHORS.md{% else %}{{ cookiecutter.full_name }}{% endif %}.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -75,12 +77,13 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-{% elif cookiecutter.open_source_license == 'GNU General Public License v3' -%}
+
+{%- elif cookiecutter.open_source_license == 'GNU General Public License v3' -%}
 GNU GENERAL PUBLIC LICENSE
                       Version 3, 29 June 2007
 
     {{ cookiecutter.project_short_description }}
-    Copyright (C) {% now 'local', '%Y' %}  {{ cookiecutter.full_name }}
+    Copyright (c) {% now 'local', '%Y' %} {% if cookiecutter.repository_owner == "arup-group" %}Arup{% elif cookiecutter.create_author_file == "y" %}{{ cookiecutter.package_name }} developers & contributors listed in AUTHORS.md{% else %}{{ cookiecutter.full_name }}{% endif %}.
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/{{cookiecutter.repository_name}}/README.md
+++ b/{{cookiecutter.repository_name}}/README.md
@@ -87,6 +87,17 @@ mkdocs serve
 
 Then you can view the documentation in a browser at <http://localhost:8000/>.
 
+## License
+
+Copyright (c) {% now 'local', '%Y' %} {% if cookiecutter.repository_owner == "arup-group" %}Arup{% elif cookiecutter.create_author_file == "y" %}{{ cookiecutter.package_name }} developers & contributors listed in AUTHORS.md{% else %}{{ cookiecutter.full_name }}{% endif %}.
+
+{%- if cookiecutter.open_source_license == "Not open source" %}
+This repository is not open source.
+You will need explicit permission from the repository owner to redistribute or make any modifications to this code.
+{%- else %}
+Licensed under the {{ cookiecutter.open_source_license }}.
+{%- endif %}
+
 ## Credits
 
 This package was created with [Cookiecutter](https://github.com/audreyr/cookiecutter) and the [arup-group/cookiecutter-pypackage](https://github.com/arup-group/cookiecutter-pypackage) project template.

--- a/{{cookiecutter.repository_name}}/src/{{cookiecutter.module_name}}/__init__.py
+++ b/{{cookiecutter.repository_name}}/src/{{cookiecutter.module_name}}/__init__.py
@@ -1,5 +1,3 @@
 """Top-level module for {{ cookiecutter.module_name }}."""
 
-__author__ = """{{ cookiecutter.full_name }}"""  # triple quotes in case the name has quotes in it.
-__email__ = "{{ cookiecutter.email }}"
 __version__ = "0.1.0.dev0"


### PR DESCRIPTION
Simplifying how authors are managed and project license is documented, based on learning from an internal project.

`__author__` and `__email__` aren't strictly _needed_ in a Python project but do add maintenance burden (remembering to update them if/when updating comparable info in `pyproject.toml`), so seems best to just remove them.