### PR TITLE
Fix markdown formatting

### DIFF
--- a/{{cookiecutter.repository_name}}/.github/pull_request_template.md
+++ b/{{cookiecutter.repository_name}}/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 Fixes # .
 
-## Checklist
+# Checklist
 
 Any checks which are not relevant to the PR can be pre-checked by the PR creator.
 All others should be checked by the reviewer(s).

--- a/{{cookiecutter.repository_name}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.repository_name}}/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ on:
 
 
 jobs:
-  docs-link-check:
+  docs-lint:
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
@@ -32,7 +32,7 @@ jobs:
       extra_args: codespell
 
   docs-test:
-    needs: [docs-link-check]
+    needs: [docs-lint]
     if: github.ref != 'refs/heads/main'
     uses: arup-group/actions-city-modelling-lab/.github/workflows/docs-deploy.yml@main
     with:

--- a/{{cookiecutter.repository_name}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.repository_name}}/.github/workflows/docs.yml
@@ -15,7 +15,24 @@ on:
 
 
 jobs:
+  docs-link-check:
+    if: github.ref != 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: markdown-link-check
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        config-file: linkcheck.json
+    - if: github.event.repository.private
+      uses: pre-commit/action@v3.0.1
+      extra_args: markdownlint
+    - if: github.event.repository.private
+      uses: pre-commit/action@v3.0.1
+      extra_args: codespell
+
   docs-test:
+    needs: [docs-link-check]
     if: github.ref != 'refs/heads/main'
     uses: arup-group/actions-city-modelling-lab/.github/workflows/docs-deploy.yml@main
     with:

--- a/{{cookiecutter.repository_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repository_name}}/.pre-commit-config.yaml
@@ -15,6 +15,25 @@ repos:
         args: [ --fix, --exit-non-zero-on-fix ]
       - id: ruff-format
 
+  - repo: https://github.com/markdownlint/markdownlint
+    rev: v0.13.0
+    hooks:
+      - id: markdownlint
+        name: Markdownlint
+        description: Run markdownlint on your Markdown files
+        entry: mdl
+        language: ruby
+        files:  \.(md|mdown|markdown)$
+        args: [-r, "~MD013,~MD046"]
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.0
+    hooks:
+    - id: codespell
+      # required for config to be managed in pyproject.toml
+      additional_dependencies:
+        - tomli
+
   - repo: local
     hooks:
       # Prevent committing .rej files

--- a/{{cookiecutter.repository_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repository_name}}/.pre-commit-config.yaml
@@ -3,20 +3,20 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=1000"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit  # https://beta.ruff.rs/docs/usage/#github-action
-    rev: v0.6.8
+    rev: v0.9.2
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
       - id: ruff-format
 
   - repo: https://github.com/markdownlint/markdownlint
-    rev: v0.13.0
+    rev: v0.12.0
     hooks:
       - id: markdownlint
         name: Markdownlint

--- a/{{cookiecutter.repository_name}}/CONTRIBUTING.md
+++ b/{{cookiecutter.repository_name}}/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Some of the resources to look at if you're interested in contributing:
 
 ## Licensing
 
-{%- if cookiecutter.open_source_license == "Not open source" %}
+{% if cookiecutter.open_source_license == "Not open source" -%}
 This repository is not open source.
 You will need explicit permission from the repository owner to redistribute or make any modifications to this code.
 {%- else %}
@@ -22,7 +22,7 @@ You can open an issue on GitHub to report bugs or request new {{ cookiecutter.re
 Follow these links to submit your issue:
 
 - [Report bugs or other problems while running {{ cookiecutter.repository_name }}](https://github.com/{{ cookiecutter.repository_owner }}/{{ cookiecutter.repository_name }}/issues/new?template=BUG-REPORT.yml).
-If reporting an error, please include a full traceback in your issue.
+  If reporting an error, please include a full traceback in your issue.
 
 - [Request features that {{ cookiecutter.repository_name }} does not already include](https://github.com/{{ cookiecutter.repository_owner }}/{{ cookiecutter.repository_name }}/issues/new?template=FEATURE-REQUEST.yml).
 
@@ -60,10 +60,12 @@ When opening a pull request, please provide a clear summary of your changes!
 
 Please try to write clear commit messages. One-line messages are fine for small changes, but bigger changes should look like this:
 
-    A brief summary of the commit (max 50 characters)
+```text
+A brief summary of the commit (max 50 characters)
 
-    A paragraph or bullet-point list describing what changed and its impact,
-    covering as many lines as needed.
+A paragraph or bullet-point list describing what changed and its impact,
+covering as many lines as needed.
+```
 
 ### Code conventions
 

--- a/{{cookiecutter.repository_name}}/CONTRIBUTING.md
+++ b/{{cookiecutter.repository_name}}/CONTRIBUTING.md
@@ -46,11 +46,11 @@ To contribute changes:
 1. Commit your changes to the feature branch (you should have `pre-commit` installed to ensure your code is correctly formatted when you commit changes).
 1. Push the branch to GitHub (`git push origin new-fix-or-feature`).
 1. On GitHub, create a new [pull request](https://github.com/{{ cookiecutter.repository_owner }}/{{ cookiecutter.repository_name }}/pull/new/main) from the feature branch.
-
 {%- if cookiecutter.create_author_file == "y" %}
-When you contribute for the first time, ensure you add your name to the contributors list in `AUTHORS.md`!
 
+When you contribute for the first time, ensure you add your name to the contributors list in `AUTHORS.md`!
 {%- endif %}
+
 ### Pull requests
 
 Before submitting a pull request, check whether you have:

--- a/{{cookiecutter.repository_name}}/README.md
+++ b/{{cookiecutter.repository_name}}/README.md
@@ -4,13 +4,17 @@
 
 # {{ cookiecutter.project_title }} ({{ cookiecutter.module_name }})
 
-{% if cookiecutter.project_visibility == 'internal' %}<!--- --8<-- [end:docs] -->{% endif -%}
+{% if cookiecutter.project_visibility == 'internal' -%}
+<!--- --8<-- [end:docs] -->
 
+{% endif -%}
 [![Daily CI Build](https://github.com/{{ cookiecutter.repository_owner }}/{{ cookiecutter.repository_name }}/actions/workflows/daily-scheduled-ci.yml/badge.svg)](https://github.com/{{ cookiecutter.repository_owner }}/{{ cookiecutter.repository_name }}/actions/workflows/daily-scheduled-ci.yml)
 [![Documentation](https://github.com/{{ cookiecutter.repository_owner }}/{{ cookiecutter.repository_name }}/actions/workflows/pages/pages-build-deployment/badge.svg?branch=gh-pages)](https://{{ cookiecutter.repository_owner }}.github.io/{{ cookiecutter.repository_name }})
 
-{% if cookiecutter.project_visibility == 'public' %}<!--- --8<-- [end:docs] -->{% endif -%}
+{% if cookiecutter.project_visibility == 'public' -%}
+<!--- --8<-- [end:docs] -->
 
+{% endif -%}
 ## Documentation
 
 For more detailed instructions, see our [documentation](https://{{ cookiecutter.repository_owner }}.github.io/{{ cookiecutter.repository_name }}/latest).
@@ -25,10 +29,11 @@ To install {{ cookiecutter.module_name }}
 Arup users on Windows can install `miniforge` from the Arup software shop by downloading "VS Code for Python" and then access `conda` from the VSCode integrated terminal.
 
 ### As a user
+
 <!--- --8<-- [start:docs-install-user] -->
 
 ``` shell
-{% if cookiecutter.upload_conda_package == "y" %}
+{% if cookiecutter.upload_conda_package == "y" -%}
 conda create -n {{ cookiecutter.repository_name }} -c conda-forge -c {{ cookiecutter.conda_channel }} {{ cookiecutter.package_name }}
 conda activate {{ cookiecutter.repository_name }}
 {% elif cookiecutter.upload_pip_package == "y" %}
@@ -47,10 +52,13 @@ conda activate {{ cookiecutter.repository_name }}
 pip install --no-deps -e .
 {%- endif %}
 ```
+
 <!--- --8<-- [end:docs-install-user] -->
 
 ### As a developer
+
 <!--- --8<-- [start:docs-install-dev] -->
+
 ``` shell
 git clone git@github.com:{{ cookiecutter.repository_owner }}/{{ cookiecutter.repository_name }}.git
 cd {{ cookiecutter.repository_name }}
@@ -58,7 +66,9 @@ conda create -n {{ cookiecutter.repository_name }} -c conda-forge --file require
 conda activate {{ cookiecutter.repository_name }}
 pip install --no-deps -e .
 ```
+
 <!--- --8<-- [end:docs-install-dev] -->
+
 For more detailed instructions, see our [documentation](https://{{ cookiecutter.repository_owner }}.github.io/{{ cookiecutter.repository_name }}/latest/installation/).
 
 ## Contributing
@@ -69,8 +79,8 @@ Before making contributions to the {{ cookiecutter.module_name }} source code, s
 If you plan to make changes to the code then please make regular use of the following tools to verify the codebase while you work:
 
 - `pre-commit`: run `pre-commit install` in your command line to load inbuilt checks that will run every time you commit your changes.
-The checks are: 1. check no large files have been staged, 2. lint python files for major errors, 3. format python files to conform with the [pep8 standard](https://peps.python.org/pep-0008/).
-You can also run these checks yourself at any time to ensure staged changes are clean by simple calling `pre-commit`.
+  The checks are: 1. check no large files have been staged, 2. lint python files for major errors, 3. format python files to conform with the [pep8 standard](https://peps.python.org/pep-0008/).
+  You can also run these checks yourself at any time to ensure staged changes are clean by simple calling `pre-commit`.
 - `pytest` - run the unit test suite and check test coverage.
 - `pytest -p memray -m "high_mem" --no-cov` (not available on Windows) - after installing memray (`conda install memray pytest-memray`), test that memory and time performance does not exceed benchmarks.
 

--- a/{{cookiecutter.repository_name}}/docs/contributing.md
+++ b/{{cookiecutter.repository_name}}/docs/contributing.md
@@ -31,7 +31,7 @@ To find beginner-friendly existing bugs and feature requests you may like to sta
 To create a development environment for {{ cookiecutter.module_name }}, with all libraries required for development and quality assurance installed, it is easiest to install {{ cookiecutter.package_name }} using the [conda](https://docs.conda.io/en/latest/) package manager, as follows:
 
 1. Install conda with the [miniforge](https://github.com/conda-forge/miniforge?tab=readme-ov-file#download) executable for your operating system.
-Arup users on Windows can install `miniforge` from the Arup software shop by downloading "VS Code for Python".
+   Arup users on Windows can install `miniforge` from the Arup software shop by downloading "VS Code for Python".
 1. Open the command line (or the VSCode "integrated terminal" in Windows).
 1. Download (a.k.a., clone) the {{ cookiecutter.repository_name }} repository: `git clone git@github.com:{{ cookiecutter.repository_owner }}/{{ cookiecutter.repository_name }}.git`
 1. Change into the `{{ cookiecutter.repository_name }}` directory: `cd {{ cookiecutter.repository_name }}`
@@ -52,11 +52,11 @@ Either way, you should add your environment as a jupyter kernel, so the example 
 If you plan to make changes to the code then please make regular use of the following tools to verify the codebase while you work:
 
 - `pre-commit`: run `pre-commit install` in your command line to load inbuilt checks that will run every time you commit your changes.
-The checks are: 1. check no large files have been staged, 2. lint python files for major errors, 3. format python files to conform with the [PEP8 standard](https://peps.python.org/pep-0008/).
-You can also run these checks yourself at any time to ensure staged changes are clean by calling `pre-commit`.
+  The checks are: 1. check no large files have been staged, 2. lint python files for major errors, 3. format python files to conform with the [PEP8 standard](https://peps.python.org/pep-0008/).
+  You can also run these checks yourself at any time to ensure staged changes are clean by calling `pre-commit`.
 - `pytest` - run the unit test suite and check test coverage.
 
-{%- if cookiecutter.create_jupyter_notebook_directory|lower == "y" %}
+{% if cookiecutter.create_jupyter_notebook_directory|lower == "y" -%}
 !!! note
 
     If you already have an environment called `{{ cookiecutter.repository_name }}` on your system (e.g., for a stable installation of the package), you will need to [chose a different environment name][choosing-a-different-environment-name].
@@ -67,9 +67,9 @@ You can also run these checks yourself at any time to ensure staged changes are 
 
 The following options allow you to strip down the test suite to the bare essentials:
 
-{%- if cookiecutter.create_jupyter_notebook_directory|lower == "y" %}
+{% if cookiecutter.create_jupyter_notebook_directory|lower == "y" -%}
 1. The test suite includes unit tests and integration tests (in the form of jupyter notebooks found in the `examples` directory).
-The integration tests can be slow, so if you want to avoid them during development, you should run `pytest tests/`.
+   The integration tests can be slow, so if you want to avoid them during development, you should run `pytest tests/`.
 {%- endif %}
 1. You can avoid generating coverage reports, by adding the `--no-cov` argument: `pytest --no-cov`.
 
@@ -84,9 +84,9 @@ The integration tests can be slow, so if you want to avoid them during developme
 If you are running on a UNIX device (i.e., **not*- on Windows), you can test whether any changes you have made adversely impact memory and time performance as follows:
 
 1. Install [memray](https://bloomberg.github.io/memray/index.html) in your `{{ cookiecutter.repository_name }}` conda environment: `conda install memray pytest-memray`.
-2. Run the memory profiling integration test: `pytest -p memray -m "high_mem" --no-cov`.
-3. Optionally, to visualise the memory allocation, run `pytest -p memray -m "high_mem" --no-cov --memray-bin-path=[my_path] --memray-bin-prefix=[my_prefix]` - where you must define `[my_path]` and `[my_prefix]` - followed by `memray flamegraph [my_path]/[my_prefix]-tests-test_100_memory_profiling.py-test_mem.bin`.
-You will then find the HTML report at `[my_path]/memray-flamegraph-[my_prefix]-tests-test_100_memory_profiling.py-test_mem.html`.
+1. Run the memory profiling integration test: `pytest -p memray -m "high_mem" --no-cov`.
+1. Optionally, to visualise the memory allocation, run `pytest -p memray -m "high_mem" --no-cov --memray-bin-path=[my_path] --memray-bin-prefix=[my_prefix]` - where you must define `[my_path]` and `[my_prefix]` - followed by `memray flamegraph [my_path]/[my_prefix]-tests-test_100_memory_profiling.py-test_mem.bin`.
+   You will then find the HTML report at `[my_path]/memray-flamegraph-[my_prefix]-tests-test_100_memory_profiling.py-test_mem.html`.
 
 All together:
 
@@ -114,8 +114,8 @@ Here are some use-cases that you may come across in which you are considering up
 
     Add a Markdown file to the top-level in `docs`, e.g. `docs/my-page.md`.
     Then, add a reference to that file within the `nav` key in `mkdocs.yml`, e.g.:
-    ```yaml
 
+    ```yaml
     nav:
     - Home: index.md
     - Installation: installation.md
@@ -125,11 +125,14 @@ Here are some use-cases that you may come across in which you are considering up
 
     You can also just rely on your document header to define the name in the navigation:
     `my-page.md`
+
     ```md
     # My Page
     ...
     ```
+
     `mkdocs.yml`
+
     ```yaml
     nav:
     ...
@@ -195,7 +198,7 @@ It uses [Pa11y](https://pa11y.org/) to test each page, providing a report where 
 If you find that your documentation has issues, here are some possible ways to resolve them:
 
 - Many issues come from the translation of markdown files to HTML.
-If these issues are blockers, you should raise them in the upstream [MkDocs-Material](https://github.com/squidfunk/mkdocs-material/issues) repository.
+  If these issues are blockers, you should raise them in the upstream [MkDocs-Material](https://github.com/squidfunk/mkdocs-material/issues) repository.
 - If issues are not blockers (e.g. an unlabelled hyperlink that is not available to any user, irrespective of their accessibility constraints), then you can add them to the `.pallyci` configuration file [`ignore` list](https://github.com/pa11y/pa11y?tab=readme-ov-file#ignore-array) or [`hideElements` string](https://github.com/pa11y/pa11y?tab=readme-ov-file#hideelements-string).
 - If you can solve the issue by updating the documentation configuration (e.g. colour scheme contrast levels, font sizes), then you can test using Pa11y locally before you push online as follows (A local [Node.js installation](https://nodejs.org/en/download/package-manager) is required):
 
@@ -207,7 +210,7 @@ If these issues are blockers, you should raise them in the upstream [MkDocs-Mate
 
     The results will be printed to the console and will be available as a navigable set of HTML pages at `reports/pa11y/index.html`.
 - If you are still unsure what part of the documentation an issue is referring to since it referencing HTML classes/ids etc., rather than Markdown files, then we recommend using the inbuilt accessibility checkers available in most common browsers.
-First, serve your documentation locally, then use e.g., the [Mozilla Firefox accessibility inspector](https://firefox-source-docs.mozilla.org/devtools-user/accessibility_inspector/) to check for issues.
+  First, serve your documentation locally, then use e.g., the [Mozilla Firefox accessibility inspector](https://firefox-source-docs.mozilla.org/devtools-user/accessibility_inspector/) to check for issues.
 {%- endif %}
 
 ## Updating the project when the template updates

--- a/{{cookiecutter.repository_name}}/docs/installation.md
+++ b/{{cookiecutter.repository_name}}/docs/installation.md
@@ -1,7 +1,7 @@
 
 # Installation
 
-## Setting up a user environment
+## Installing a user environment
 
 {% if cookiecutter.project_visibility == "internal" and (cookiecutter.upload_conda_package == "y"  or cookiecutter.upload_pip_package == "y") -%}
 !!! note
@@ -11,7 +11,7 @@
 As a `{{ cookiecutter.module_name }}` user, it is easiest to install using the [conda](https://docs.conda.io/en/latest/) package manager, as follows:
 
 1. Install conda with the [miniforge](https://github.com/conda-forge/miniforge?tab=readme-ov-file#download) executable for your operating system.
-Arup users on Windows can install `miniforge` from the Arup software shop by downloading "VS Code for Python".
+   Arup users on Windows can install `miniforge` from the Arup software shop by downloading "VS Code for Python".
 1. Open the command line (or the VSCode "integrated terminal" in Windows).
 {%- if cookiecutter.upload_conda_package == "y" %}
 1. Create the {{ cookiecutter.repository_name }} conda environment: `conda create -n {{ cookiecutter.repository_name }} -c conda-forge -c {{ cookiecutter.conda_channel }} {{ cookiecutter.package_name }}`
@@ -30,7 +30,7 @@ Arup users on Windows can install `miniforge` from the Arup software shop by dow
 1. Create the {{ cookiecutter.repository_name }} conda environment: `conda create -n {{ cookiecutter.repository_name }} -c conda-forge -c city-modelling-lab --file requirements/base.txt`
 1. Activate the {{ cookiecutter.repository_name }} conda environment: `conda activate {{ cookiecutter.repository_name }}`
 1. Install the {{ cookiecutter.package_name }} package into the environment, ignoring dependencies (we have dealt with those when creating the conda environment): `pip install --no-deps .`
-{% endif %}
+{%- endif %}
 
 All together:
 
@@ -71,7 +71,7 @@ ipython kernel install --user --name=[my-env-name]
 ```
 {%- endif %}
 
-## Setting up a development environment
+## Installing a development environment
 
 The install instructions are slightly different to create a development environment compared to a user environment:
 

--- a/{{cookiecutter.repository_name}}/linkcheck.json
+++ b/{{cookiecutter.repository_name}}/linkcheck.json
@@ -1,0 +1,17 @@
+{
+    "ignorePatterns": [
+      {
+        "pattern": "^https://github.com/arup-group"
+      },
+      {
+        "pattern": "^https://arup.sharepoint.com"
+      },
+      {
+        "pattern": "^https://arup-my.sharepoint.com"
+      },
+      {
+        "pattern": "^https://aws.arup.com"
+      },
+    ]
+
+}

--- a/{{cookiecutter.repository_name}}/pyproject.toml
+++ b/{{cookiecutter.repository_name}}/pyproject.toml
@@ -113,6 +113,13 @@ convention = "google"
 max-doc-length = 200
 ignore-overlong-task-comments = true
 
+[tool.codespell]
+skip = "tests/*.py,AUTHORS.md"
+count = ""
+quiet-level = 3
+# Uncomment and add words that are false flags as a comma delimited string
+# ignore-words-list = ""
+
 [tool.setuptools.packages.find]
 include = ["{{ cookiecutter.module_name }}*"]
 where = ["src"]


### PR DESCRIPTION
Found the occasional weird markdown formatting caused when resolving templates. I've fixed those I know of and added in pre-commit checks to lint markdown files and to check spelling.

I've also added markdown link checks, but put that in as a GH action rather than pre-commit as it (a) takes longer to run and (b) would likely complain if you commit locally while offline (e.g. on a train). The config for this checker comes from the arup `city-modelling-lab` repo.