### PR TITLE
markdownlint -> pymarkdown

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -61,7 +61,7 @@ jobs:
           include-hidden-files: true
 
   test-template:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, windows-latest]
     needs: build-template
     steps:
       - name: Download built package

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -61,7 +61,11 @@ jobs:
           include-hidden-files: true
 
   test-template:
-    runs-on: [ubuntu-latest, windows-latest]
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
     needs: build-template
     steps:
       - name: Download built package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - EditorConfig file within template (#50).
 - Documentation accessibility checking (#41).
 - Documentation FAQ in contributing guidelines (#41).
+- Markdown linting as part of CI checks (#61, #62).
 
 ### Fixed
 

--- a/{{cookiecutter.repository_name}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.repository_name}}/.github/workflows/docs.yml
@@ -27,11 +27,11 @@ jobs:
     - if: github.event.repository.private
       uses: pre-commit/action@v3.0.1
       with:
-        extra_args: markdownlint
+        extra_args: pymarkdown --all-files
     - if: github.event.repository.private
       uses: pre-commit/action@v3.0.1
       with:
-        extra_args: codespell
+        extra_args: codespell --all-files
 
   docs-test:
     needs: [docs-lint]

--- a/{{cookiecutter.repository_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repository_name}}/.pre-commit-config.yaml
@@ -8,31 +8,32 @@ repos:
       - id: check-added-large-files
         args: ["--maxkb=1000"]
 
-  - repo: https://github.com/astral-sh/ruff-pre-commit  # https://beta.ruff.rs/docs/usage/#github-action
+  - repo: https://github.com/astral-sh/ruff-pre-commit # https://beta.ruff.rs/docs/usage/#github-action
     rev: v0.9.2
     hooks:
       - id: ruff
-        args: [ --fix, --exit-non-zero-on-fix ]
+        args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
-  - repo: https://github.com/markdownlint/markdownlint
-    rev: v0.12.0
+  - repo: https://github.com/jackdewinter/pymarkdown
+    rev: v0.9.27
     hooks:
-      - id: markdownlint
-        name: Markdownlint
-        description: Run markdownlint on your Markdown files
-        entry: mdl
-        language: ruby
-        files:  \.(md|mdown|markdown)$
-        args: [-r, "~MD013,~MD046"]
+      - id: pymarkdown
+        args:
+          - -d
+            # line-length: we don't want to enforce line length as that can be too restrictive
+            # first-line-heading: we get false positives due to commented sections at the start of Markdown files
+            # code-block-style: MKDocs Material admonitions use indented blocks which raises a code block style false positive
+          - line-length,first-line-heading,code-block-style
+          - "scan"
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.0
     hooks:
-    - id: codespell
-      # required for config to be managed in pyproject.toml
-      additional_dependencies:
-        - tomli
+      - id: codespell
+        # required for config to be managed in pyproject.toml
+        additional_dependencies:
+          - tomli
 
   - repo: local
     hooks:
@@ -49,6 +50,6 @@ repos:
         language: pygrep
         types: [text]
 
-ci:  # https://pre-commit.ci/
+ci: # https://pre-commit.ci/
   autofix_prs: false
   autoupdate_schedule: monthly


### PR DESCRIPTION
Fixes #62 

This moves to using a pure python dependency for linting Markdown, to mitigate cross-platform issues when running the linter.

I've also added a windows runner to the template test CI. This won't catch everything, but would have caught this issue (as pre-commit is run on a boilerplate baked project)!